### PR TITLE
Rudimentary useability

### DIFF
--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -115,12 +115,23 @@
 (defun company-sourcekit--post-completion (completed)
   "Post completion - expand yasnippet if necessary"
   (when company-sourcekit-use-yasnippet
+    (when company-sourcekit-verbose (message "[company-sourcekit] expanding yasnippet template"))
     (let ((template (company-sourcekit--build-yasnippet (get-text-property 0 'sourcetext completed))))
-      (yas-expand-snippet template (- (point) (length completed)) (point)))))
+      (when company-sourcekit-verbose (message "[company-sourcekit] %s" template)
+      (yas-expand-snippet template (- (point) (length completed)) (point))))))
 
 (defun company-sourcekit--build-yasnippet (sourcetext)
   "Build a yasnippet-compatible snippet from the given source text"
-  (replace-regexp-in-string "<#T.*?#>" "$0" sourcetext))
+  (let ((counter 0))
+    (replace-regexp-in-string
+     "<#T##\\(.*?\\)#>"
+     (lambda (str)
+       ;; <#T##Int#> - No label, argument only
+       (save-match-data
+         (string-match "<#T##\\(.*?\\)#>" str)
+         (setq counter (+ counter 1))
+         (format "${%i:%s}" counter (car (split-string (match-string 1 str) "#")))))
+     sourcetext)))
 
 (provide 'company-sourcekit)
 ;;; company-sourcekit.el ends here

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -117,8 +117,8 @@
   (when company-sourcekit-use-yasnippet
     (when company-sourcekit-verbose (message "[company-sourcekit] expanding yasnippet template"))
     (let ((template (company-sourcekit--build-yasnippet (get-text-property 0 'sourcetext completed))))
-      (when company-sourcekit-verbose (message "[company-sourcekit] %s" template)
-      (yas-expand-snippet template (- (point) (length completed)) (point))))))
+      (when company-sourcekit-verbose (message "[company-sourcekit] %s" template))
+      (yas-expand-snippet template (- (point) (length completed)) (point)))))
 
 (defun company-sourcekit--build-yasnippet (sourcetext)
   "Build a yasnippet-compatible snippet from the given source text"

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t -*-
 ;;; company-sourcekit --- company-mode completion back-end for sourcekit
 
 ;;; Commentary:

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -96,10 +96,11 @@
   "Given json returned from sourcekitten, turn it into a list compatible with company-mode"
   (append (mapcar
            (lambda (l)
-             (let ((desc (cdr (assoc 'descriptionKey l)))
+             (let ((name (cdr (assoc 'name l)))
+                   (desc (cdr (assoc 'descriptionKey l)))
                    (src (cdr (assoc 'sourcetext l)))
                    (type (cdr (assoc 'typeName l))))
-               (propertize (company-sourcekit--clean-sourcetext src)
+               (propertize name
                            'sourcetext src
                            'description desc
                            'type type)))
@@ -115,10 +116,6 @@
   (when company-sourcekit-use-yasnippet
     (let ((template (company-sourcekit--build-yasnippet (get-text-property 0 'sourcetext completed))))
       (yas-expand-snippet template (- (point) (length completed)) (point)))))
-
-(defun company-sourcekit--clean-sourcetext (sourcetext)
-  "Clean up the source text"
-  (replace-regexp-in-string "<#T.*?#>" "" sourcetext))
 
 (defun company-sourcekit--build-yasnippet (sourcetext)
   "Build a yasnippet-compatible snippet from the given source text"

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -18,7 +18,8 @@
   "Location of sourcekitten executable."
     :type 'file)
 
-(defcustom company-sourcekit-use-yasnippet nil
+(defcustom company-sourcekit-use-yasnippet
+  (fboundp 'yas-minor-mode)
   "Should Yasnippet be used for completion expansion"
   :type 'boolean)
 

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -21,8 +21,8 @@
   "Should Yasnippet be used for completion expansion"
   :type 'boolean)
 
-(defcustom company-sourcekit-verbose t
-  "Should company-sourcekit log to the messages buffer"
+(defcustom company-sourcekit-verbose nil
+  "Should log to the messages buffer"
   :type 'boolean)
 
 (defun company-sourcekit--fetch (prefix)

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -122,16 +122,14 @@
 
 (defun company-sourcekit--build-yasnippet (sourcetext)
   "Build a yasnippet-compatible snippet from the given source text"
-  (let ((counter 0))
-    (replace-regexp-in-string
-     "<#T##\\(.*?\\)#>"
-     (lambda (str)
-       ;; <#T##Int#> - No label, argument only
-       (save-match-data
-         (string-match "<#T##\\(.*?\\)#>" str)
-         (setq counter (+ counter 1))
-         (format "${%i:%s}" counter (car (split-string (match-string 1 str) "#")))))
-     sourcetext)))
+  (replace-regexp-in-string
+   "<#T##\\(.*?\\)#>"
+   (lambda (str)
+     ;; <#T##Int#> - No label, argument only
+     (save-match-data
+       (string-match "<#T##\\(.*?\\)#>" str)
+       (format "${%s}" (car (split-string (match-string 1 str) "#")))))
+   sourcetext))
 
 (provide 'company-sourcekit)
 ;;; company-sourcekit.el ends here

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -52,7 +52,7 @@
 
 (defun company-sourcekit--annotation (candidate)
   "Returns the type of the completion candidate"
-  (format " :: %s" (get-text-property 0 'type candidate)))
+  (format " %s" (get-text-property 0 'type candidate)))
 
 (defun company-sourcekit--candidates (prefix callback)
   "Use sourcekitten to get a list of completion candidates."

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -17,7 +17,7 @@
   "Location of sourcekitten executable."
     :type 'file)
 
-(defcustom company-sourcekit-use-yasnippet t
+(defcustom company-sourcekit-use-yasnippet nil
   "Should Yasnippet be used for completion expansion"
   :type 'boolean)
 

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -32,6 +32,8 @@
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-sourcekit))
+    (init (unless company-sourcekit-sourcekitten-executable
+            (error "[company-sourcekit] sourcekitten not found in PATH")))
     (sorted t)
     (no-cache t)
     (prefix (company-sourcekit--prefix))

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -21,15 +21,19 @@
   "Should Yasnippet be used for completion expansion"
   :type 'boolean)
 
+(defcustom company-sourcekit-verbose t
+  "Should company-sourcekit log to the messages buffer"
+  :type 'boolean)
+
 (defun company-sourcekit--fetch (prefix)
   "Use sourcekitten to get a list of completion candidates.
 PREFIX is the file offset passed to sourcekitten."
-  (message "Retrieving from sourcekitten using PREFIX %s" prefix)
+  (when company-sourcekit-verbose (message "Retrieving from sourcekitten using PREFIX %s" prefix))
   (let ((tmpfile (make-temp-file "sourcekitten"))
         (offset (point)))
     (write-region (point-min) (point-max) tmpfile)
     (with-temp-buffer
-      (message "Calling: sourcekitten complete --file %s --offset %d" tmpfile offset)
+      (when company-sourcekit-verbose (message "Calling: sourcekitten complete --file %s --offset %d" tmpfile offset))
       (call-process company-sourcekit-sourcekitten-executable nil (current-buffer) nil
                     "complete" "--file" tmpfile "--offset" (number-to-string offset))
       (setq return-json (buffer-substring-no-properties (point-min) (point-max)))

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -9,10 +9,11 @@
 ;;; Code:
 
 (defgroup company-sourcekit nil
-  "Completion backend for swift projects"
+  "Completion backend that uses sourcekit"
   :group 'company)
 
-(defcustom company-sourcekit-sourcekitten-executable (executable-find "sourcekitten")
+(defcustom company-sourcekit-sourcekitten-executable
+  (executable-find "sourcekitten")
   "Location of sourcekitten executable."
     :type 'file)
 
@@ -20,72 +21,32 @@
   "Should Yasnippet be used for completion expansian"
   :type 'boolean)
 
-(defvar-local company-sourcekit--workspace 'unknown)
-(defun company-sourcekit--workspace ()
-  "Retrieve the xcode workspace for the current file by searching up the directory hierarchy."
-  (if (eq company-sourcekit--workspace 'unknown)
-    (setq company-sourcekit--workspace
-      (let ((mFile
-             (locate-dominating-file buffer-file-name
-               (lambda (parent)
-                 (and
-                   (not (null parent))
-                   (file-directory-p parent)
-                   (directory-files parent nil ".*?\\.xcworkspace"))))))
-        (unless (null mFile)
-          (expand-file-name mFile)))))
-  company-sourcekit--workspace)
-
-(defvar-local company-sourcekit--project 'unknown)
-(defun company-sourcekit--project ()
-  "Retrieve the xcode project for the current file by searching up the directory hierarchy."
-  (if (eq company-sourcekit--project 'unknown)
-    (setq company-sourcekit--project
-      (let ((mFile
-             (locate-dominating-file buffer-file-name
-               (lambda (parent)
-                 (and
-                   (not (null parent))
-                   (file-directory-p parent)
-                   (directory-files parent nil ".*?\\.xcodeproj"))))))
-        (unless (null mFile)
-          (expand-file-name mFile)))))
-  company-sourcekit--project)
-
 (defun company-sourcekit--fetch (prefix)
   "Use sourcekitten to get a list of completion candidates.
 PREFIX is the file offset passed to sourcekitten."
   (message "Retrieving from sourcekitten using PREFIX %s" prefix)
   (let ((tmpfile (make-temp-file "sourcekitten"))
-         (offset (point)))
+        (offset (point)))
     (write-region (point-min) (point-max) tmpfile)
-    (setq skworkspace (company-sourcekit--workspace))
-    (setq skproject (company-sourcekit--project))
     (with-temp-buffer
-      (let ((workspace-or-project (if skworkspace
-                                    (concat "-workspace " skworkspace)
-                                    (if skproject
-                                      (concat "-project " skproject) ""))))
-        (message "Calling process with --file %s --offset %d %s" tmpfile offset workspace-or-project)
-        (call-process company-sourcekit-sourcekitten-executable nil (current-buffer) nil
-          "complete" "--file" tmpfile "--offset" (number-to-string offset) workspace-or-project)
-        (setq return-json (buffer-substring-no-properties (point-min) (point-max)))
-        (append (mapcar
-                  (lambda (l)
-                    (let* ((counter 0)
-                            (v (cdr (assoc 'sourcetext l)))
-                            (n (cdr (assoc 'descriptionKey l)))
-                            (f (replace-regexp-in-string "<#T##\\(.*?\\)#>"
-                                 (lambda (blk)
-                                   (save-match-data
-                                     (string-match "<#T##\\(.*?\\)#>" blk)
-                                     (setq counter (+ 1 counter))
-                                     (format "${%i:%s}" counter (car (split-string (match-string 1 blk) "#")))
-                                     )) v)))
-                      (propertize n 'yas-template f)
-                      )
-                    )
-          (json-read-from-string return-json)) nil)))))
+      (message "Calling: sourcekitten complete --file %s --offset %d" tmpfile offset)
+      (call-process company-sourcekit-sourcekitten-executable nil (current-buffer) nil
+                    "complete" "--file" tmpfile "--offset" (number-to-string offset))
+      (setq return-json (buffer-substring-no-properties (point-min) (point-max)))
+      (append (mapcar
+               (lambda (l)
+                 (let* ((counter 0)
+                        (v (cdr (assoc 'sourcetext l)))
+                        (n (cdr (assoc 'descriptionKey l)))
+                        (f (replace-regexp-in-string "<#T##\\(.*?\\)#>"
+                                                     (lambda (blk)
+                                                       (save-match-data
+                                                         (string-match "<#T##\\(.*?\\)#>" blk)
+                                                         (setq counter (+ 1 counter))
+                                                         (format "${%i:%s}" counter (car (split-string (match-string 1 blk) "#")))
+                                                         )) v)))
+                   (propertize n 'yas-template f)))
+               (json-read-from-string return-json)) nil))))
 
 (declare-function yas-expand-snippet "yasnippet")
 (defun company-sourcekit (command &optional prefix &rest ignored)
@@ -100,11 +61,11 @@ IGNORED ignores the rest of the arguments"
                  (company-grab-symbol-cons "\\." 1)))
     (candidates (company-sourcekit--fetch prefix))
     (post-completion
-      (when company-sourcekit-use-yasnippet
-        (let ((template (get-text-property 0 'yas-template prefix)))
-          (yas-expand-snippet template
-            (- (point) (length prefix))
-            (point)))))
+     (when company-sourcekit-use-yasnippet
+       (let ((template (get-text-property 0 'yas-template prefix)))
+         (yas-expand-snippet template
+                             (- (point) (length prefix))
+                             (point)))))
     (sorted t)))
 
 (provide 'company-sourcekit)

--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -18,7 +18,7 @@
     :type 'file)
 
 (defcustom company-sourcekit-use-yasnippet t
-  "Should Yasnippet be used for completion expansian"
+  "Should Yasnippet be used for completion expansion"
   :type 'boolean)
 
 (defun company-sourcekit--fetch (prefix)


### PR DESCRIPTION
This patch does a couple of things:
- Vanilla (non project-specific) completion actually works
- Makes completion queries async, performance is a lot better
- Adds meta and annotation to completions
- No longer requires `lexical-binding` to be on globally
- Auto-detects yasnippet and enables yasnippet integration
- Setting to toggle verbose mode
- Lots of refactoring

For anyone who wants to try this currently highly-unstable package,
please note that you'll need to build from master until
https://github.com/jpsim/SourceKitten/commit/522b6274bcd2b7d3f46225ea9787630d483fb9e8
makes it into a sourcekitten release.
