### PR TITLE
Fix package

### DIFF
--- a/sourcekit.el
+++ b/sourcekit.el
@@ -1,6 +1,5 @@
-;;; -*- lexical-binding: t -*-
-;;; sourcekit --- library to interact with sourcekitdaemon
-;;; Package-Requires: ((dash "2.12.1") (dash-functional "1.2.0")
+;;; sourcekit.el --- library to interact with sourcekitdaemon -*- lexical-binding: t -*-
+;; Package-Requires: ((emacs "24.3") (dash "2.12.1") (dash-functional "1.2.0"))
 
 ;;; Commentary:
 

--- a/sourcekit.el
+++ b/sourcekit.el
@@ -5,7 +5,6 @@
 
 ;;; Code:
 
-(require 'company)
 (require 'cl-lib)
 (require 'dash)
 (require 'dash-functional)


### PR DESCRIPTION
This PR is same as #8 for `sourcekit.el` 
- Fix package header
- Correct dependency list(`defvar-local` was introduced at Emacs 24.3)
- Remove company import, because `sourcekit.el` does not use company.
