### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/company-sourcekit.el
+++ b/company-sourcekit.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nathankot/company-sourcekit
 ;; Keywords: abbrev
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "24.3") (company "0.8.12") (dash "2.12.1") (dash-functional "1.2.0") (sourcekit "0.2.0"))
+;; Package-Requires: ((emacs "24.3") (company "0.8.12") (dash "2.18.0") (sourcekit "0.2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -32,7 +32,6 @@
 (require 'cl-lib)
 (require 'json)
 (require 'dash)
-(require 'dash-functional)
 (require 'sourcekit)
 
 (defgroup company-sourcekit nil

--- a/sourcekit.el
+++ b/sourcekit.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nathankot/company-sourcekit
 ;; Keywords: tools, processes
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "24.3") (dash "2.12.1") (dash-functional "1.2.0") (request "0.2.0"))
+;; Package-Requires: ((emacs "24.3") (dash "2.18.0") (request "0.2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -32,7 +32,6 @@
 
 (require 'cl-lib)
 (require 'dash)
-(require 'dash-functional)
 (require 'request)
 
 (defgroup sourcekit nil


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218